### PR TITLE
Add C-BetterSearch

### DIFF
--- a/src/main/java/task/TaskList.java
+++ b/src/main/java/task/TaskList.java
@@ -136,5 +136,6 @@ public class TaskList {
     public Task get(int loc) {
         return tasks.get(loc);
     }
+    
 
 }


### PR DESCRIPTION
Find command only return searchs if the query is exactly the same as item

Find command should be more flexible and matches items even if keyword matches the item only partially

Let's update the search algorithm to match partial keywords